### PR TITLE
changes described in Issue #1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 endif ()
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DPTHASH_ENABLE_ALL_ENCODERS")
+
 if (UNIX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 endif ()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DPTHASH_ENABLE_ALL_ENCODERS")
-
 if (UNIX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,8 @@ if (UNIX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 
     # For hardware popcount and pdep
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mbmi2 -msse4.2")
+    #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mbmi2 -msse4.2")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
 
     # Extensive warnings
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-braces")

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Authors
 -------
 * [Giulio Ermanno Pibiri](http://pages.di.unipi.it/pibiri/), <giulio.ermanno.pibiri@isti.cnr.it>
 * [Roberto Trani](), <roberto.trani@isti.cnr.it>
-* some contribution has also been made by [Peter Beling](http://pbeling.w8.pl/), <piotr.beling@wmii.uni.lodz.pl>
+* some contribution has also been made by [Piotr Beling](http://pbeling.w8.pl/), <piotr.beling@wmii.uni.lodz.pl>
 
 
 References

--- a/README.md
+++ b/README.md
@@ -50,22 +50,37 @@ Usage
 
 Execute `./mphf_benchmark -h` to print an help message describing all command line parameters, whose output is as follows
 ```
-Usage: ./mphf_benchmark [-h,--help] algorithm [-n num_keys] [--num_construction_runs num_construction_runs] [--num_lookup_runs num_lookup_runs] [--verbose] [--seed seed]
+Usage: ./mphf_benchmark [-h,--help] algorithm [--variant variant] [-n num_keys] [--num_construction_runs num_construction_runs] [--num_lookup_runs num_lookup_runs] [--verbose] [--seed seed] [--threads threads] [--gen generator]
 
  algorithm
-        The name of the algorithm to run. One among `fch`, `chd`, `bbhash`, `emphf`, `recsplit`, `pthash`.
+	The name of the algorithm to run. One among `fch`, `chd`, `bbhash`, `emphf`, `recsplit`, `pthash`, `ppthash`.
+
+ [--variant variant]
+	Variant of the selected algorithm to test, interpretation depends on method (default: 0 = all variants).
+
  [-n num_keys]
-        The number of 64-bit random keys to use for the test. If it is not provided, then keys are read from the input (one per line).
+	The number of random keys to use for the test. If it is not provided, then keys are read from the input (one per line).
+
  [--num_construction_runs num_construction_runs]
-        Number of times to perform the construction. (default: 1)
+	Number of times to perform the construction. (default: 1)
+
  [--num_lookup_runs num_lookup_runs]
-        Number of times to perform the lookup test. (default: 1)
+	Number of times to perform the lookup test. (default: 1)
+
  [--verbose]
-        Verbose output during construction. (default: false)
+	Verbose output during construction. (default: false)
+
  [--seed seed]
-        Seed used for construction. (default: 0)
+	Seed used for construction. (default: 0)
+
+ [--threads threads]
+	Number of threads used in multi-threaded calculations. (default: 0 = auto)
+
+ [--gen generator]
+	The method of generating keys, one of: `64` (default), `xs32` (xor-shift 32), `xs64` (xor-shift 64)
+
  [-h,--help]
-        Print this help text and silently exits.
+	Print this help text and silently exits.
 ```
 
 To actually use the benchmark, and reproduce Table 5 of [*PTHash: Revisiting FCH Minimal Perfect Hashing*](https://arxiv.org/abs/2104.10402) [1] (except [GOV](https://github.com/vigna/Sux4J), which is Java-based), execute the following commands
@@ -102,6 +117,7 @@ Authors
 -------
 * [Giulio Ermanno Pibiri](http://pages.di.unipi.it/pibiri/), <giulio.ermanno.pibiri@isti.cnr.it>
 * [Roberto Trani](), <roberto.trani@isti.cnr.it>
+* some contribution has also been made by [Peter Beling](http://pbeling.w8.pl/), <piotr.beling@wmii.uni.lodz.pl>
 
 
 References

--- a/include/bbhash_wrapper.hpp
+++ b/include/bbhash_wrapper.hpp
@@ -10,7 +10,7 @@ namespace mphf {
 template <typename T, typename Hasher>
 struct BBhashWrapper {
     struct Builder {
-        Builder(uint32_t gamma, uint32_t num_threads = 1)
+        Builder(double gamma, uint32_t num_threads = 1)
             : m_gamma(gamma), m_num_threads(num_threads) {
             if (gamma < 1) { throw std::invalid_argument("`gamma` must be greater or equal to 1"); }
             if (num_threads < 1) {
@@ -43,7 +43,8 @@ struct BBhashWrapper {
         }
 
     private:
-        uint32_t m_gamma, m_num_threads;
+        double m_gamma;
+        uint32_t m_num_threads;
         std::string m_name;
     };
 

--- a/include/pthash_wrapper.hpp
+++ b/include/pthash_wrapper.hpp
@@ -49,7 +49,8 @@ struct PTHashWrapper {
             config.c = m_c;
             config.alpha = m_alpha;
             config.num_threads = m_num_threads;
-            config.num_partitions = m_partitions;
+            //config.num_partitions = m_partitions;
+            config.minimal_output = true;
             config.verbose_output = verbose;
             config.seed = seed;
 
@@ -79,8 +80,8 @@ struct PTHashWrapper {
 
 private:
     std::conditional_t<partitioned,
-        pthash::partitioned_mphf<pthash::murmurhash2_64, Encoder>,
-        pthash::single_mphf<pthash::murmurhash2_64, Encoder>
+        pthash::partitioned_phf<pthash::murmurhash2_64, Encoder, true>,
+        pthash::single_phf<pthash::murmurhash2_64, Encoder, true>
     > m_pthash;
 };
 

--- a/include/pthash_wrapper.hpp
+++ b/include/pthash_wrapper.hpp
@@ -12,7 +12,7 @@ namespace mphf {
 template <typename Encoder>
 struct PTHashWrapper {
     struct Builder {
-        Builder(float c, float alpha) : m_c(c), m_alpha(alpha) {
+        Builder(float c, float alpha,uint64_t num_threads = 1) : m_c(c), m_alpha(alpha), m_num_threads(num_threads) {
             if (c < 1.45) { throw std::invalid_argument("`c` must be greater or equal to 1.45"); }
             if (alpha <= 0 || 1 < alpha) {
                 throw std::invalid_argument(
@@ -23,6 +23,7 @@ struct PTHashWrapper {
             ss << "PTHash(encoder=" << Encoder::name();
             ss << ", c=" << c;
             ss << ", alpha=" << alpha;
+            ss << ", threads=" << num_threads;
             ss << ")";
             m_name = ss.str();
         }
@@ -41,6 +42,7 @@ struct PTHashWrapper {
             pthash::build_configuration config;
             config.c = m_c;
             config.alpha = m_alpha;
+            config.num_threads = m_num_threads;
             config.verbose_output = verbose;
             config.seed = seed;
 
@@ -54,6 +56,7 @@ struct PTHashWrapper {
     private:
         float m_c, m_alpha;
         std::string m_name;
+        uint64_t m_num_threads;
     };
 
     template <typename T>

--- a/include/pthash_wrapper.hpp
+++ b/include/pthash_wrapper.hpp
@@ -12,9 +12,8 @@ namespace mphf {
 template <bool partitioned, typename Encoder>
 struct PTHashWrapper {
     struct Builder {
-        Builder(float c, float alpha, uint64_t num_threads = 1, uint64_t partitions = 0)
-            : m_c(c), m_alpha(alpha), m_num_threads(num_threads),
-              m_partitions(partitions == 0 ? num_threads : partitions)
+        Builder(float c, float alpha, uint64_t num_threads = 1, uint64_t num_of_keys = 0)
+            : m_c(c), m_alpha(alpha), m_num_threads(num_threads)
         {
             if (c < 1.45) { throw std::invalid_argument("`c` must be greater or equal to 1.45"); }
             if (alpha <= 0 || 1 < alpha) {
@@ -23,11 +22,24 @@ struct PTHashWrapper {
             }
 
             std::stringstream ss;
-            ss << "PTHash(encoder=" << Encoder::name();
+            ss << (partitioned ? "P" : "") << "PTHash(encoder=" << Encoder::name();
             ss << ", c=" << c;
             ss << ", alpha=" << alpha;
+            ss << ", threads=" << num_threads;
             if (partitioned) {
-                ss << ", threads=" << num_threads;
+                num_of_keys /= 5000000;
+                if (num_of_keys == 0) {
+                    m_partitions = 1;
+                } else {
+                    num_of_keys--;  // calc nearest power of two
+                    num_of_keys |= num_of_keys >> 1;
+                    num_of_keys |= num_of_keys >> 2;
+                    num_of_keys |= num_of_keys >> 4;
+                    num_of_keys |= num_of_keys >> 8;
+                    num_of_keys |= num_of_keys >> 16;
+                    num_of_keys++;
+                    m_partitions = num_of_keys;
+                }
                 ss << ", partitions=" << m_partitions;
             }
             ss << ")";
@@ -49,7 +61,7 @@ struct PTHashWrapper {
             config.c = m_c;
             config.alpha = m_alpha;
             config.num_threads = m_num_threads;
-            //config.num_partitions = m_partitions;
+            if (partitioned) config.num_partitions = m_partitions;
             config.minimal_output = true;
             config.verbose_output = verbose;
             config.seed = seed;

--- a/include/pthash_wrapper.hpp
+++ b/include/pthash_wrapper.hpp
@@ -9,11 +9,12 @@
 
 namespace mphf {
 
-template <typename Encoder>
+template <bool partitioned, typename Encoder>
 struct PTHashWrapper {
     struct Builder {
-        Builder(float c, float alpha, uint64_t num_threads = 1)
-            : m_c(c), m_alpha(alpha), m_num_threads(num_threads)
+        Builder(float c, float alpha, uint64_t num_threads = 1, uint64_t partitions = 0)
+            : m_c(c), m_alpha(alpha), m_num_threads(num_threads),
+              m_partitions(partitions == 0 ? num_threads : partitions)
         {
             if (c < 1.45) { throw std::invalid_argument("`c` must be greater or equal to 1.45"); }
             if (alpha <= 0 || 1 < alpha) {
@@ -25,7 +26,10 @@ struct PTHashWrapper {
             ss << "PTHash(encoder=" << Encoder::name();
             ss << ", c=" << c;
             ss << ", alpha=" << alpha;
-            ss << ", threads=" << num_threads;
+            if (partitioned) {
+                ss << ", threads=" << num_threads;
+                ss << ", partitions=" << m_partitions;
+            }
             ss << ")";
             m_name = ss.str();
         }
@@ -61,6 +65,7 @@ struct PTHashWrapper {
         float m_c, m_alpha;
         std::string m_name;
         uint64_t m_num_threads;
+        uint64_t m_partitions;
     };
 
     template <typename T>
@@ -74,12 +79,10 @@ struct PTHashWrapper {
     }
 
 private:
-    pthash::single_phf<pthash::murmurhash2_64, Encoder, true> m_pthash;
-
-    /*std::conditional_t<partitioned,
+    std::conditional_t<partitioned,
         pthash::partitioned_phf<pthash::murmurhash2_64, Encoder, true>,
         pthash::single_phf<pthash::murmurhash2_64, Encoder, true>
-    > m_pthash;*/
+    > m_pthash;
 };
 
 }  // namespace mphf

--- a/include/pthash_wrapper.hpp
+++ b/include/pthash_wrapper.hpp
@@ -9,12 +9,11 @@
 
 namespace mphf {
 
-template <bool partitioned, typename Encoder>
+template <typename Encoder>
 struct PTHashWrapper {
     struct Builder {
-        Builder(float c, float alpha, uint64_t num_threads = 1, uint64_t partitions = 0)
-            : m_c(c), m_alpha(alpha), m_num_threads(num_threads),
-              m_partitions(partitions == 0 ? num_threads : partitions)
+        Builder(float c, float alpha, uint64_t num_threads = 1)
+            : m_c(c), m_alpha(alpha), m_num_threads(num_threads)
         {
             if (c < 1.45) { throw std::invalid_argument("`c` must be greater or equal to 1.45"); }
             if (alpha <= 0 || 1 < alpha) {
@@ -26,10 +25,7 @@ struct PTHashWrapper {
             ss << "PTHash(encoder=" << Encoder::name();
             ss << ", c=" << c;
             ss << ", alpha=" << alpha;
-            if (partitioned) {
-                ss << ", threads=" << num_threads;
-                ss << ", partitions=" << m_partitions;
-            }
+            ss << ", threads=" << num_threads;
             ss << ")";
             m_name = ss.str();
         }
@@ -65,7 +61,6 @@ struct PTHashWrapper {
         float m_c, m_alpha;
         std::string m_name;
         uint64_t m_num_threads;
-        uint64_t m_partitions;
     };
 
     template <typename T>
@@ -79,10 +74,12 @@ struct PTHashWrapper {
     }
 
 private:
-    std::conditional_t<partitioned,
+    pthash::single_phf<pthash::murmurhash2_64, Encoder, true> m_pthash;
+
+    /*std::conditional_t<partitioned,
         pthash::partitioned_phf<pthash::murmurhash2_64, Encoder, true>,
         pthash::single_phf<pthash::murmurhash2_64, Encoder, true>
-    > m_pthash;
+    > m_pthash;*/
 };
 
 }  // namespace mphf

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -202,6 +202,32 @@ std::vector<T> create_random_distinct_keys(uint64_t num_keys, uint64_t seed) {
     return keys;
 }
 
+std::vector<uint32_t> create_xorshift32_keys(uint32_t num_keys, uint32_t seed) {
+    if (seed == 0) seed = 1234;
+    std::vector<uint32_t> result;
+    result.reserve(num_keys);
+    for (uint32_t i = 0; i < num_keys; ++i) {
+        seed ^= seed << 13;
+        seed ^= seed >> 17;
+        seed ^= seed << 5;
+        result.push_back(seed);
+    }
+    return result;
+}
+
+std::vector<uint64_t> create_xorshift64_keys(uint64_t num_keys, uint64_t seed) {
+    if (seed == 0) seed = 1234;
+    std::vector<uint64_t> result;
+    result.reserve(num_keys);
+    for (uint64_t i = 0; i < num_keys; ++i) {
+        seed ^= seed << 13;
+        seed ^= seed >> 7;
+        seed ^= seed << 17;
+        result.push_back(seed);
+    }
+    return result;
+}
+
 std::vector<std::string> read_keys_from_stream(std::istream& is, char delimiter = '\n') {
     std::vector<std::string> keys;
     std::string line;

--- a/src/mphf_benchmark.cpp
+++ b/src/mphf_benchmark.cpp
@@ -24,7 +24,7 @@ template <typename T>
 struct TestEnvironment {
     TestEnvironment(std::vector<T>&& keys, uint32_t num_construction_runs = 1,
                     uint32_t num_lookup_runs = 5, uint64_t seed = 0, bool verbose = false)
-        : keys(keys)
+        : keys(std::move(keys))
         , num_construction_runs(num_construction_runs)
         , num_lookup_runs(num_lookup_runs)
         , seed(seed)

--- a/src/mphf_benchmark.cpp
+++ b/src/mphf_benchmark.cpp
@@ -92,7 +92,7 @@ struct TestEnvironment {
     const bool verbose;
 };
 
-enum Algorithm { FCH, CHD, BBhash, EMPHF, RecSplit, PTHash, ALL };
+enum Algorithm { FCH, CHD, BBhash, EMPHF, RecSplit, PTHash, PPTHash, ALL };
 
 template <typename T>
 void test_algorithms(TestEnvironment<T> const& testenv, Algorithm const& algorithm, unsigned variant) {
@@ -152,15 +152,28 @@ void test_algorithms(TestEnvironment<T> const& testenv, Algorithm const& algorit
     }
 
     if (algorithm == PTHash || algorithm == ALL) {
-        if (variant == 1 || variant == 0) testenv.test(typename mphf::PTHashWrapper<pthash::compact_compact>::Builder(7.0, 0.99));
-        if (variant == 2 || variant == 0) testenv.test(typename mphf::PTHashWrapper<pthash::dictionary_dictionary>::Builder(11.0, 0.88));
-        if (variant == 3 || variant == 0) testenv.test(typename mphf::PTHashWrapper<pthash::elias_fano>::Builder(6.0, 0.99));
-        if (variant == 4 || variant == 0) testenv.test(typename mphf::PTHashWrapper<pthash::dictionary_dictionary>::Builder(7.0, 0.94));
+        if (variant == 1 || variant == 0) testenv.test(typename mphf::PTHashWrapper<false, pthash::compact_compact>::Builder(7.0, 0.99));
+        if (variant == 2 || variant == 0) testenv.test(typename mphf::PTHashWrapper<false, pthash::dictionary_dictionary>::Builder(11.0, 0.88));
+        if (variant == 3 || variant == 0) testenv.test(typename mphf::PTHashWrapper<false, pthash::elias_fano>::Builder(6.0, 0.99));
+        if (variant == 4 || variant == 0) testenv.test(typename mphf::PTHashWrapper<false, pthash::dictionary_dictionary>::Builder(7.0, 0.94));
         if (threads_num > 1) {
-            if (variant == 5 || variant == 0) testenv.test(typename mphf::PTHashWrapper<pthash::compact_compact>::Builder(7.0, 0.99, threads_num));
-            if (variant == 6 || variant == 0) testenv.test(typename mphf::PTHashWrapper<pthash::dictionary_dictionary>::Builder(11.0, 0.88, threads_num));
-            if (variant == 7 || variant == 0) testenv.test(typename mphf::PTHashWrapper<pthash::elias_fano>::Builder(6.0, 0.99, threads_num));
-            if (variant == 8 || variant == 0) testenv.test(typename mphf::PTHashWrapper<pthash::dictionary_dictionary>::Builder(7.0, 0.94, threads_num));
+            if (variant == 5 || variant == 0) testenv.test(typename mphf::PTHashWrapper<false, pthash::compact_compact>::Builder(7.0, 0.99, threads_num));
+            if (variant == 6 || variant == 0) testenv.test(typename mphf::PTHashWrapper<false, pthash::dictionary_dictionary>::Builder(11.0, 0.88, threads_num));
+            if (variant == 7 || variant == 0) testenv.test(typename mphf::PTHashWrapper<false, pthash::elias_fano>::Builder(6.0, 0.99, threads_num));
+            if (variant == 8 || variant == 0) testenv.test(typename mphf::PTHashWrapper<false, pthash::dictionary_dictionary>::Builder(7.0, 0.94, threads_num));
+        }
+    }
+
+    if (algorithm == PPTHash || algorithm == ALL) {
+        if (variant == 1 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::compact_compact>::Builder(7.0, 0.99, 1, threads_num));
+        if (variant == 2 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::dictionary_dictionary>::Builder(11.0, 0.88, 1, threads_num));
+        if (variant == 3 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::elias_fano>::Builder(6.0, 0.99, 1, threads_num));
+        if (variant == 4 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::dictionary_dictionary>::Builder(7.0, 0.94, 1, threads_num));
+        if (threads_num > 1) {
+            if (variant == 5 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::compact_compact>::Builder(7.0, 0.99, threads_num));
+            if (variant == 6 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::dictionary_dictionary>::Builder(11.0, 0.88, threads_num));
+            if (variant == 7 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::elias_fano>::Builder(6.0, 0.99, threads_num));
+            if (variant == 8 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::dictionary_dictionary>::Builder(7.0, 0.94, threads_num));
         }
     }
 }
@@ -203,7 +216,7 @@ int main(int argc, char** argv) {
     // recognize the algorithm
     const std::unordered_map<std::string, Algorithm> name_to_algorithm{
         {"fch", FCH},           {"chd", CHD},       {"bbhash", BBhash}, {"emphf", EMPHF},
-        {"recsplit", RecSplit}, {"pthash", PTHash}, {"all", ALL},
+        {"recsplit", RecSplit}, {"pthash", PTHash}, {"ppthash", PPTHash}, {"all", ALL},
     };
     auto algorithm_it = name_to_algorithm.find(algorithm_name);
     if (algorithm_it == name_to_algorithm.end()) {

--- a/src/mphf_benchmark.cpp
+++ b/src/mphf_benchmark.cpp
@@ -156,6 +156,12 @@ void test_algorithms(TestEnvironment<T> const& testenv, Algorithm const& algorit
         if (variant == 2 || variant == 0) testenv.test(typename mphf::PTHashWrapper<false, pthash::dictionary_dictionary>::Builder(11.0, 0.88));
         if (variant == 3 || variant == 0) testenv.test(typename mphf::PTHashWrapper<false, pthash::elias_fano>::Builder(6.0, 0.99));
         if (variant == 4 || variant == 0) testenv.test(typename mphf::PTHashWrapper<false, pthash::dictionary_dictionary>::Builder(7.0, 0.94));
+        if (threads_num > 1) {
+            if (variant == 5 || variant == 0) testenv.test(typename mphf::PTHashWrapper<false, pthash::compact_compact>::Builder(7.0, 0.99, threads_num));
+            if (variant == 6 || variant == 0) testenv.test(typename mphf::PTHashWrapper<false, pthash::dictionary_dictionary>::Builder(11.0, 0.88, threads_num));
+            if (variant == 7 || variant == 0) testenv.test(typename mphf::PTHashWrapper<false, pthash::elias_fano>::Builder(6.0, 0.99, threads_num));
+            if (variant == 8 || variant == 0) testenv.test(typename mphf::PTHashWrapper<false, pthash::dictionary_dictionary>::Builder(7.0, 0.94, threads_num));
+        }
     }
 
     if (algorithm == PPTHash || algorithm == ALL) {

--- a/src/mphf_benchmark.cpp
+++ b/src/mphf_benchmark.cpp
@@ -92,7 +92,7 @@ struct TestEnvironment {
     const bool verbose;
 };
 
-enum Algorithm { FCH, CHD, BBhash, EMPHF, RecSplit, PTHash, PPTHash, ALL };
+enum Algorithm { FCH, CHD, BBhash, EMPHF, RecSplit, PTHash, ALL };
 
 template <typename T>
 void test_algorithms(TestEnvironment<T> const& testenv, Algorithm const& algorithm, unsigned variant) {
@@ -152,28 +152,15 @@ void test_algorithms(TestEnvironment<T> const& testenv, Algorithm const& algorit
     }
 
     if (algorithm == PTHash || algorithm == ALL) {
-        if (variant == 1 || variant == 0) testenv.test(typename mphf::PTHashWrapper<false, pthash::compact_compact>::Builder(7.0, 0.99));
-        if (variant == 2 || variant == 0) testenv.test(typename mphf::PTHashWrapper<false, pthash::dictionary_dictionary>::Builder(11.0, 0.88));
-        if (variant == 3 || variant == 0) testenv.test(typename mphf::PTHashWrapper<false, pthash::elias_fano>::Builder(6.0, 0.99));
-        if (variant == 4 || variant == 0) testenv.test(typename mphf::PTHashWrapper<false, pthash::dictionary_dictionary>::Builder(7.0, 0.94));
+        if (variant == 1 || variant == 0) testenv.test(typename mphf::PTHashWrapper<pthash::compact_compact>::Builder(7.0, 0.99));
+        if (variant == 2 || variant == 0) testenv.test(typename mphf::PTHashWrapper<pthash::dictionary_dictionary>::Builder(11.0, 0.88));
+        if (variant == 3 || variant == 0) testenv.test(typename mphf::PTHashWrapper<pthash::elias_fano>::Builder(6.0, 0.99));
+        if (variant == 4 || variant == 0) testenv.test(typename mphf::PTHashWrapper<pthash::dictionary_dictionary>::Builder(7.0, 0.94));
         if (threads_num > 1) {
-            if (variant == 5 || variant == 0) testenv.test(typename mphf::PTHashWrapper<false, pthash::compact_compact>::Builder(7.0, 0.99, threads_num));
-            if (variant == 6 || variant == 0) testenv.test(typename mphf::PTHashWrapper<false, pthash::dictionary_dictionary>::Builder(11.0, 0.88, threads_num));
-            if (variant == 7 || variant == 0) testenv.test(typename mphf::PTHashWrapper<false, pthash::elias_fano>::Builder(6.0, 0.99, threads_num));
-            if (variant == 8 || variant == 0) testenv.test(typename mphf::PTHashWrapper<false, pthash::dictionary_dictionary>::Builder(7.0, 0.94, threads_num));
-        }
-    }
-
-    if (algorithm == PPTHash || algorithm == ALL) {
-        if (variant == 1 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::compact_compact>::Builder(7.0, 0.99, 1, threads_num));
-        if (variant == 2 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::dictionary_dictionary>::Builder(11.0, 0.88, 1, threads_num));
-        if (variant == 3 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::elias_fano>::Builder(6.0, 0.99, 1, threads_num));
-        if (variant == 4 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::dictionary_dictionary>::Builder(7.0, 0.94, 1, threads_num));
-        if (threads_num > 1) {
-            if (variant == 5 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::compact_compact>::Builder(7.0, 0.99, threads_num));
-            if (variant == 6 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::dictionary_dictionary>::Builder(11.0, 0.88, threads_num));
-            if (variant == 7 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::elias_fano>::Builder(6.0, 0.99, threads_num));
-            if (variant == 8 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::dictionary_dictionary>::Builder(7.0, 0.94, threads_num));
+            if (variant == 5 || variant == 0) testenv.test(typename mphf::PTHashWrapper<pthash::compact_compact>::Builder(7.0, 0.99, threads_num));
+            if (variant == 6 || variant == 0) testenv.test(typename mphf::PTHashWrapper<pthash::dictionary_dictionary>::Builder(11.0, 0.88, threads_num));
+            if (variant == 7 || variant == 0) testenv.test(typename mphf::PTHashWrapper<pthash::elias_fano>::Builder(6.0, 0.99, threads_num));
+            if (variant == 8 || variant == 0) testenv.test(typename mphf::PTHashWrapper<pthash::dictionary_dictionary>::Builder(7.0, 0.94, threads_num));
         }
     }
 }
@@ -216,7 +203,7 @@ int main(int argc, char** argv) {
     // recognize the algorithm
     const std::unordered_map<std::string, Algorithm> name_to_algorithm{
         {"fch", FCH},           {"chd", CHD},       {"bbhash", BBhash}, {"emphf", EMPHF},
-        {"recsplit", RecSplit}, {"pthash", PTHash}, {"ppthash", PPTHash}, {"all", ALL},
+        {"recsplit", RecSplit}, {"pthash", PTHash}, {"all", ALL},
     };
     auto algorithm_it = name_to_algorithm.find(algorithm_name);
     if (algorithm_it == name_to_algorithm.end()) {

--- a/src/mphf_benchmark.cpp
+++ b/src/mphf_benchmark.cpp
@@ -181,7 +181,7 @@ int main(int argc, char** argv) {
                "The name of the algorithm to run. One among `fch`, `chd`, "
                "`bbhash`, `emphf`, `recsplit`, `pthash`, `ppthash`.");
     parser.add("variant",
-               "Variant of the selected algorithm to test, interpretation depends on method (default: 0 = all variants).",
+               "Variant of the selected algorithm to test, interpretation depends on method. (default: 0 = all variants)",
                "--variant", false);
     parser.add("num_keys",
                "The number of random keys to use for the test. "

--- a/src/mphf_benchmark.cpp
+++ b/src/mphf_benchmark.cpp
@@ -258,7 +258,7 @@ int main(int argc, char** argv) {
             std::cerr << "The number of keys cannot be zero" << std::endl;
             return 1;
         }
-        std::cout << "Generating " << num_keys << " random keys by " << generator << " generator (the name of the generator contains the size of keys in bits)." << std::endl;
+        std::cout << "Generating " << num_keys << " random keys by " << generator << " generator (the name of the generator contains the size of each key in bits)." << std::endl;
         if (generator == "64" || generator == "xs64") {
             std::vector<uint64_t> keys = generator == "64" ?
                         create_random_distinct_keys<uint64_t>(num_keys, seed) :

--- a/src/mphf_benchmark.cpp
+++ b/src/mphf_benchmark.cpp
@@ -165,15 +165,16 @@ void test_algorithms(TestEnvironment<T> const& testenv, Algorithm const& algorit
     }
 
     if (algorithm == PPTHash || algorithm == ALL) {
-        if (variant == 1 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::compact_compact>::Builder(7.0, 0.99, 1, threads_num));
-        if (variant == 2 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::dictionary_dictionary>::Builder(11.0, 0.88, 1, threads_num));
-        if (variant == 3 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::elias_fano>::Builder(6.0, 0.99, 1, threads_num));
-        if (variant == 4 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::dictionary_dictionary>::Builder(7.0, 0.94, 1, threads_num));
+        auto keys_num = testenv.keys.size();
+        if (variant == 1 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::compact_compact>::Builder(7.0, 0.99, 1, keys_num));
+        if (variant == 2 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::dictionary_dictionary>::Builder(11.0, 0.88, 1, keys_num));
+        if (variant == 3 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::elias_fano>::Builder(6.0, 0.99, 1, keys_num));
+        if (variant == 4 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::dictionary_dictionary>::Builder(7.0, 0.94, 1, keys_num));
         if (threads_num > 1) {
-            if (variant == 5 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::compact_compact>::Builder(7.0, 0.99, threads_num));
-            if (variant == 6 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::dictionary_dictionary>::Builder(11.0, 0.88, threads_num));
-            if (variant == 7 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::elias_fano>::Builder(6.0, 0.99, threads_num));
-            if (variant == 8 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::dictionary_dictionary>::Builder(7.0, 0.94, threads_num));
+            if (variant == 5 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::compact_compact>::Builder(7.0, 0.99, threads_num, keys_num));
+            if (variant == 6 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::dictionary_dictionary>::Builder(11.0, 0.88, threads_num, keys_num));
+            if (variant == 7 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::elias_fano>::Builder(6.0, 0.99, threads_num, keys_num));
+            if (variant == 8 || variant == 0) testenv.test(typename mphf::PTHashWrapper<true, pthash::dictionary_dictionary>::Builder(7.0, 0.94, threads_num, keys_num));
         }
     }
 }

--- a/src/mphf_benchmark.cpp
+++ b/src/mphf_benchmark.cpp
@@ -95,39 +95,43 @@ struct TestEnvironment {
 enum Algorithm { FCH, CHD, BBhash, EMPHF, RecSplit, PTHash, ALL };
 
 template <typename T>
-void test_algorithms(TestEnvironment<T> const& testenv, Algorithm const& algorithm) {
+void test_algorithms(TestEnvironment<T> const& testenv, Algorithm const& algorithm, unsigned variant) {
     using Hasher = mphf::hasher::Hasher<mphf::base_hasher::Murmur2BaseHasher>;
 
     // test the algorithms
     if (algorithm == FCH || algorithm == ALL) {
-        testenv.test(mphf::FCH<Hasher>::Builder(3, 0.6, 0.3));
-        testenv.test(mphf::FCH<Hasher>::Builder(4, 0.6, 0.3));
-        testenv.test(mphf::FCH<Hasher>::Builder(5, 0.6, 0.3));
-        testenv.test(mphf::FCH<Hasher>::Builder(6, 0.6, 0.3));
-        testenv.test(mphf::FCH<Hasher>::Builder(7, 0.6, 0.3));
+        if (variant == 3 || variant == 0) testenv.test(mphf::FCH<Hasher>::Builder(3, 0.6, 0.3));
+        if (variant == 4 || variant == 0) testenv.test(mphf::FCH<Hasher>::Builder(4, 0.6, 0.3));
+        if (variant == 5 || variant == 0) testenv.test(mphf::FCH<Hasher>::Builder(5, 0.6, 0.3));
+        if (variant == 6 || variant == 0) testenv.test(mphf::FCH<Hasher>::Builder(6, 0.6, 0.3));
+        if (variant == 7 || variant == 0) testenv.test(mphf::FCH<Hasher>::Builder(7, 0.6, 0.3));
     }
 
     if (algorithm == CHD || algorithm == ALL) {
-        testenv.test(mphf::CHDWrapper::Builder(1.0));
-        testenv.test(mphf::CHDWrapper::Builder(2.0));
-        testenv.test(mphf::CHDWrapper::Builder(3.0));
-        testenv.test(mphf::CHDWrapper::Builder(4.0));
-        testenv.test(mphf::CHDWrapper::Builder(5.0));
-        testenv.test(mphf::CHDWrapper::Builder(6.0));
+        if (variant == 1 || variant == 0) testenv.test(mphf::CHDWrapper::Builder(1.0));
+        if (variant == 2 || variant == 0) testenv.test(mphf::CHDWrapper::Builder(2.0));
+        if (variant == 3 || variant == 0) testenv.test(mphf::CHDWrapper::Builder(3.0));
+        if (variant == 4 || variant == 0) testenv.test(mphf::CHDWrapper::Builder(4.0));
+        if (variant == 5 || variant == 0) testenv.test(mphf::CHDWrapper::Builder(5.0));
+        if (variant == 6 || variant == 0) testenv.test(mphf::CHDWrapper::Builder(6.0));
     }
 
     if (algorithm == EMPHF || algorithm == ALL) {
-        testenv.test(mphf::EMPHFWrapper::Builder());
-        testenv.test(mphf::EMPHFHEMWrapper::Builder());
+        if (variant == 1 || variant == 0) testenv.test(mphf::EMPHFWrapper::Builder());
+        if (variant == 2 || variant == 0) testenv.test(mphf::EMPHFHEMWrapper::Builder());
     }
 
     if (algorithm == BBhash || algorithm == ALL) {
-        testenv.test(typename mphf::BBhashWrapper<T, Hasher>::Builder(1.0));
-        testenv.test(typename mphf::BBhashWrapper<T, Hasher>::Builder(1.0, 4));
-        testenv.test(typename mphf::BBhashWrapper<T, Hasher>::Builder(1.5));
-        testenv.test(typename mphf::BBhashWrapper<T, Hasher>::Builder(1.5, 4));
-        testenv.test(typename mphf::BBhashWrapper<T, Hasher>::Builder(2.0));
-        testenv.test(typename mphf::BBhashWrapper<T, Hasher>::Builder(2.0, 4));
+        if (variant == 1 || variant == 0) {
+            testenv.test(typename mphf::BBhashWrapper<T, Hasher>::Builder(1.0));
+            testenv.test(typename mphf::BBhashWrapper<T, Hasher>::Builder(1.0, 4));
+        }
+        //testenv.test(typename mphf::BBhashWrapper<T, Hasher>::Builder(1.5));
+        //testenv.test(typename mphf::BBhashWrapper<T, Hasher>::Builder(1.5, 4));
+        if (variant == 2 || variant == 0) {
+            testenv.test(typename mphf::BBhashWrapper<T, Hasher>::Builder(2.0));
+            testenv.test(typename mphf::BBhashWrapper<T, Hasher>::Builder(2.0, 4));
+        }
     }
 
     if (algorithm == RecSplit || algorithm == ALL) {
@@ -138,18 +142,18 @@ void test_algorithms(TestEnvironment<T> const& testenv, Algorithm const& algorit
             std::cerr << "RecSplit algorithm is not implemented on Apple" << std::endl;
         }
 #else
-        testenv.test(typename mphf::RecSplitWrapper<5>::Builder(5));
-        testenv.test(typename mphf::RecSplitWrapper<8>::Builder(100));
-        testenv.test(typename mphf::RecSplitWrapper<12>::Builder(9));
+        if (variant == 1 || variant == 5 || variant == 0) testenv.test(typename mphf::RecSplitWrapper<5>::Builder(5));
+        if (variant == 2 || variant == 8 || variant == 0) testenv.test(typename mphf::RecSplitWrapper<8>::Builder(100));
+        if (variant == 3 || variant == 12 || variant == 0) testenv.test(typename mphf::RecSplitWrapper<12>::Builder(9));
 #endif
     }
 
     if (algorithm == PTHash || algorithm == ALL) {
-        testenv.test(typename mphf::PTHashWrapper<pthash::compact_compact>::Builder(7.0, 0.99));
-        testenv.test(
+        if (variant == 1 || variant == 7 || variant == 0) testenv.test(typename mphf::PTHashWrapper<pthash::compact_compact>::Builder(7.0, 0.99));
+        if (variant == 2 || variant == 11 || variant == 0) testenv.test(
             typename mphf::PTHashWrapper<pthash::dictionary_dictionary>::Builder(11.0, 0.88));
-        testenv.test(typename mphf::PTHashWrapper<pthash::elias_fano>::Builder(6.0, 0.99));
-        testenv.test(
+        if (variant == 3 || variant == 6 || variant == 0) testenv.test(typename mphf::PTHashWrapper<pthash::elias_fano>::Builder(6.0, 0.99));
+        if (variant == 4 || variant == 7 || variant == 0) testenv.test(
             typename mphf::PTHashWrapper<pthash::dictionary_dictionary>::Builder(7.0, 0.94));
     }
 }
@@ -159,8 +163,11 @@ int main(int argc, char** argv) {
     parser.add("algorithm",
                "The name of the algorithm to run. One among `fch`, `chd`, "
                "`bbhash`, `emphf`, `recsplit`, `pthash`.");
+    parser.add("variant",
+               "Variant of the selected algorithm to test, interpretation depents on method (default: 0 = all variants).",
+               "-v", false);
     parser.add("num_keys",
-               "The number of 64-bit random keys to use for the test. "
+               "The number of random keys to use for the test. "
                "If it is not provided, then keys are read from the input (one "
                "per line).",
                "-n", false);
@@ -176,6 +183,7 @@ int main(int argc, char** argv) {
     if (!parser.parse()) { return 1; }
 
     std::string algorithm_name = parser.get<std::string>("algorithm");
+    unsigned variant = parser.parsed("variant") ? parser.get<uint64_t>("variant") : 0;
     uint64_t num_keys = parser.parsed("num_keys") ? parser.get<uint64_t>("num_keys") : 0;
     bool verbose = parser.parsed("verbose") && parser.get<bool>("verbose");
     uint32_t num_construction_runs =
@@ -218,7 +226,7 @@ int main(int argc, char** argv) {
                   << std::round(average_size * 100) / 100 << std::endl;
         TestEnvironment<std::string> testenv(std::move(keys), num_construction_runs,
                                              num_lookup_runs, seed, verbose);
-        test_algorithms(testenv, algorithm);
+        test_algorithms(testenv, algorithm, variant);
     } else {
         if (generator != "64" && generator != "xs32" && generator != "xs64") {
             std::cerr << "Wrong generator name." << std::endl;
@@ -235,12 +243,12 @@ int main(int argc, char** argv) {
                         create_xorshift64_keys(num_keys, seed);
             TestEnvironment<uint64_t> testenv(std::move(keys), num_construction_runs, num_lookup_runs,
                                               seed, verbose);
-            test_algorithms(testenv, algorithm);
+            test_algorithms(testenv, algorithm, variant);
         } else {
             std::vector<uint32_t> keys = create_xorshift32_keys(num_keys, seed);
             TestEnvironment<uint32_t> testenv(std::move(keys), num_construction_runs, num_lookup_runs,
                                               seed, verbose);
-            test_algorithms(testenv, algorithm);
+            test_algorithms(testenv, algorithm, variant);
         }
     }
     return 0;


### PR DESCRIPTION
* I've added xor-shifts 32 and 64 generators for keys,
* I've updated PTHash to the newest version and added its support for its partitioned variant, * some methods (especially PTHash) are run also with multiple threads,
* only one variant of the method can be run with new variant flag,
* I fixed the bug that cause coping all the keys.