### PR TITLE
added --gen stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Usage: ./mphf_benchmark [-h,--help] algorithm [--variant variant] [-n num_keys] 
 	Number of threads used in multi-threaded calculations. (default: 0 = auto)
 
  [--gen generator]
-	The method of generating keys, one of: `64` (default), `xs32` (xor-shift 32), `xs64` (xor-shift 64)
+	The method of generating keys, one of: `64 (default if -n is given)`, `xs32` (xor-shift 32), `xs64` (xor-shift 64), `stdin` (strings from stdin; default if -n is not given)
 
  [-h,--help]
 	Print this help text and silently exits.

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -228,9 +228,16 @@ std::vector<uint64_t> create_xorshift64_keys(uint64_t num_keys, uint64_t seed) {
     return result;
 }
 
-std::vector<std::string> read_keys_from_stream(std::istream& is, char delimiter = '\n') {
+std::vector<std::string> read_keys_from_stream(std::istream& is, char delimiter = '\n', uint64_t num_keys = 0) {
     std::vector<std::string> keys;
     std::string line;
-    while (getline(is, line, delimiter)) { keys.push_back(line); }
+    if (num_keys != 0) {
+        keys.reserve(num_keys);
+        while (num_keys > 0 && getline(is, line, delimiter)) {
+            keys.push_back(line);
+            --num_keys;
+        }
+    } else
+        while (getline(is, line, delimiter)) { keys.push_back(line); }
     return keys;
 }


### PR DESCRIPTION
--gen stdin can be combined with -n to read exact number of string from stdin (and pre-reserve memory for them)